### PR TITLE
Use col-md-12 instead of col-auto for cards

### DIFF
--- a/_includes/choose.html
+++ b/_includes/choose.html
@@ -21,7 +21,7 @@
 		</div>
 	</div>
 	<div class="row justify-content-center">
-		<div class="col-auto">
+		<div class="col-md-12">
 			<div class="card-group">
 				<div class="card" id="download">
 					<div class="card-body">


### PR DESCRIPTION
- This centers the position of the cards (download, latest blog post and latest uploads)
- It is fine on phone also, checked through chrome devtools

- <h3>EARLIER - </h3>
![Cards](https://i.imgur.com/OmQ4FNf.png)

- <h3>AFTERWARDS - </h3>
![Cards](https://i.imgur.com/Nt4qqBT.png)